### PR TITLE
Adds peak hold feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+retrogram-rtlsdr


### PR DESCRIPTION
The idea is to store the maximum value recorded to allow picking up short transmissions. You enable it with the H key and disable with h (which will also clear the peak hold value).

I used it for TX antenna tuning yesterday by sweeping the frequency with my transmitter and looking at the peak hold chart from retroscope. You can then easily spot the resonance frequency and adjust accordingly.